### PR TITLE
Adding file format as a CSS class to allow specific CSS styling

### DIFF
--- a/dist/browser/asciidoctor-kroki.js
+++ b/dist/browser/asciidoctor-kroki.js
@@ -15945,16 +15945,25 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
   // Be careful not to specify "specialcharacters" or your diagram code won't be valid anymore!
   const subs = attrs.subs
   if (subs) {
-    diagramText = parent.$apply_subs(diagramText, parent.$resolve_subs(subs), true)
+    diagramText = parent.applySubstitutions(diagramText, parent.$resolve_subs(subs))
   }
-  const role = attrs.role
   const blockId = attrs.id
   const title = attrs.title
   const target = attrs.target
   const format = attrs.format || 'svg'
+  let role = attrs.role
+  if (role) {
+    if (format) {
+      role = `${role} kroki-format-${format} kroki`
+    } else {
+      role = `${role} kroki`
+    }
+  } else {
+    role = 'kroki'
+  }
   const imageUrl = createImageSrc(doc, diagramText, diagramType, target, format, context.vfs)
   const blockAttrs = {
-    role: role ? `${role} kroki` : 'kroki',
+    role: role,
     target: imageUrl,
     alt: target || 'diagram',
     title
@@ -15996,7 +16005,7 @@ function diagramBlockMacro (name, context) {
       }
       const role = attrs.role
       const diagramType = name
-      target = parent.$apply_subs(target, ['attributes'])
+      target = parent.applySubstitutions(target, ['attributes'])
       try {
         const diagramText = vfs.read(target)
         return processKroki(this, parent, attrs, diagramType, diagramText, context)

--- a/dist/node/asciidoctor-kroki.js
+++ b/dist/node/asciidoctor-kroki.js
@@ -41,16 +41,25 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
   // Be careful not to specify "specialcharacters" or your diagram code won't be valid anymore!
   const subs = attrs.subs
   if (subs) {
-    diagramText = parent.$apply_subs(diagramText, parent.$resolve_subs(subs), true)
+    diagramText = parent.applySubstitutions(diagramText, parent.$resolve_subs(subs))
   }
-  const role = attrs.role
   const blockId = attrs.id
   const title = attrs.title
   const target = attrs.target
   const format = attrs.format || 'svg'
+  let role = attrs.role
+  if (role) {
+    if (format) {
+      role = `${role} kroki-format-${format} kroki`
+    } else {
+      role = `${role} kroki`
+    }
+  } else {
+    role = 'kroki'
+  }
   const imageUrl = createImageSrc(doc, diagramText, diagramType, target, format, context.vfs)
   const blockAttrs = {
-    role: role ? `${role} kroki` : 'kroki',
+    role: role,
     target: imageUrl,
     alt: target || 'diagram',
     title
@@ -92,7 +101,7 @@ function diagramBlockMacro (name, context) {
       }
       const role = attrs.role
       const diagramType = name
-      target = parent.$apply_subs(target, ['attributes'])
+      target = parent.applySubstitutions(target, ['attributes'])
       try {
         const diagramText = vfs.read(target)
         return processKroki(this, parent, attrs, diagramType, diagramText, context)

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -43,14 +43,23 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
   if (subs) {
     diagramText = parent.applySubstitutions(diagramText, parent.$resolve_subs(subs))
   }
-  const role = attrs.role
   const blockId = attrs.id
   const title = attrs.title
   const target = attrs.target
   const format = attrs.format || 'svg'
+  let role = attrs.role
+  if (role) {
+    if (format) {
+      role = `${role} ${format} kroki`
+    } else {
+      role = `${role} kroki`
+    }
+  } else {
+    role = 'kroki'
+  }
   const imageUrl = createImageSrc(doc, diagramText, diagramType, target, format, context.vfs)
   const blockAttrs = {
-    role: role ? `${role} kroki` : 'kroki',
+    role: role,
     target: imageUrl,
     alt: target || 'diagram',
     title

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -50,7 +50,7 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
   let role = attrs.role
   if (role) {
     if (format) {
-      role = `${role} ${format} kroki`
+      role = `${role} kroki-format-${format} kroki`
     } else {
       role = `${role} kroki`
     }

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -67,7 +67,7 @@ alice -> bob
         AsciidoctorKroki.register(registry)
         const html = asciidoctor.convert(input, { extension_registry: registry })
         expect(html).to.contain('https://kroki.io/plantuml/png/eNpLzMlMTlXQtVNIyk8CABoDA90=')
-        expect(html).to.contain('<div class="imageblock sequence png kroki">')
+        expect(html).to.contain('<div class="imageblock sequence kroki-format-png kroki">')
       })
       it('should convert a diagram with a relative path to an image', () => {
         const input = `plantuml::${baseDir}/test/fixtures/alice.puml[svg,role=sequence]`

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -58,7 +58,7 @@ const httpGet = (uri, encoding = 'utf8') => {
     describe('When extension is registered', () => {
       it('should convert a diagram to an image', () => {
         const input = `
-[plantuml,alice-bob,svg,role=sequence]
+[plantuml,alice-bob,png,role=sequence]
 ....
 alice -> bob
 ....
@@ -66,8 +66,8 @@ alice -> bob
         const registry = asciidoctor.Extensions.create()
         AsciidoctorKroki.register(registry)
         const html = asciidoctor.convert(input, { extension_registry: registry })
-        expect(html).to.contain('https://kroki.io/plantuml/svg/eNpLzMlMTlXQtVNIyk8CABoDA90=')
-        expect(html).to.contain('<div class="imageblock sequence kroki">')
+        expect(html).to.contain('https://kroki.io/plantuml/png/eNpLzMlMTlXQtVNIyk8CABoDA90=')
+        expect(html).to.contain('<div class="imageblock sequence png kroki">')
       })
       it('should convert a diagram with a relative path to an image', () => {
         const input = `plantuml::${baseDir}/test/fixtures/alice.puml[svg,role=sequence]`

--- a/test/test.js
+++ b/test/test.js
@@ -38,7 +38,7 @@ alice -> bob
       asciidoctorKroki.register(registry)
       const html = asciidoctor.convert(input, { extension_registry: registry })
       expect(html).to.contain('https://kroki.io/plantuml/svg/eNpLzMlMTlXQtVNIyk8CABoDA90=')
-      expect(html).to.contain('<div class="imageblock sequence svg kroki">')
+      expect(html).to.contain('<div class="imageblock sequence kroki-format-svg kroki">')
     })
     it('should convert a diagram with an absolute path to an image', () => {
       const input = `plantuml::${__dirname}/fixtures/alice.puml[svg,role=sequence]`
@@ -46,7 +46,7 @@ alice -> bob
       asciidoctorKroki.register(registry)
       const html = asciidoctor.convert(input, { extension_registry: registry })
       expect(html).to.contain('https://kroki.io/plantuml/svg/eNpzKC5JLCopzc3hSszJTE5V0LVTSMpP4nJIzUsBCQIAr3EKfA==')
-      expect(html).to.contain('<div class="imageblock sequence svg kroki">')
+      expect(html).to.contain('<div class="imageblock sequence kroki-format-svg kroki">')
     })
     it('should convert a diagram with a relative path to an image', () => {
       const input = `

--- a/test/test.js
+++ b/test/test.js
@@ -38,7 +38,7 @@ alice -> bob
       asciidoctorKroki.register(registry)
       const html = asciidoctor.convert(input, { extension_registry: registry })
       expect(html).to.contain('https://kroki.io/plantuml/svg/eNpLzMlMTlXQtVNIyk8CABoDA90=')
-      expect(html).to.contain('<div class="imageblock sequence kroki">')
+      expect(html).to.contain('<div class="imageblock sequence svg kroki">')
     })
     it('should convert a diagram with an absolute path to an image', () => {
       const input = `plantuml::${__dirname}/fixtures/alice.puml[svg,role=sequence]`
@@ -46,7 +46,7 @@ alice -> bob
       asciidoctorKroki.register(registry)
       const html = asciidoctor.convert(input, { extension_registry: registry })
       expect(html).to.contain('https://kroki.io/plantuml/svg/eNpzKC5JLCopzc3hSszJTE5V0LVTSMpP4nJIzUsBCQIAr3EKfA==')
-      expect(html).to.contain('<div class="imageblock sequence kroki">')
+      expect(html).to.contain('<div class="imageblock sequence svg kroki">')
     })
     it('should convert a diagram with a relative path to an image', () => {
       const input = `


### PR DESCRIPTION
This PR adds the "format" parameter as a CSS class, so that different styling can be used for different output styles.

This helps in the case of browsers not properly rendering SVG images coming from a third-party; for example, SVG images produced in the Ditaa format appear normally on Antora sites, while SVG images produced by Blockdiag do not (tested in Chrome and Firefox) as they appear with zero width and zero height.

Having a separate CSS class would allow to add some additional parameters to fix the display of the image.