### PR TITLE
Revert "Use second optional positional attribute (target) as generated-file-name"

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -28,7 +28,7 @@ module.exports.save = function (krokiDiagram, doc, target, vfs, krokiClient) {
   const dirPath = getDirPath(doc)
   const diagramUrl = krokiDiagram.getDiagramUri(krokiClient.getServerUrl())
   const format = krokiDiagram.format
-  const diagramName = target ? `${target}.${format}` : `diag-${rusha.createHash().update(diagramUrl).digest('hex')}.${format}`
+  const diagramName = `diag-${rusha.createHash().update(diagramUrl).digest('hex')}.${format}`
   const filePath = path.format({ dir: dirPath, base: diagramName })
   let encoding
   let mediaType

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -133,7 +133,7 @@ Hello -> World
       const registry = asciidoctor.Extensions.create()
       asciidoctorKroki.register(registry)
       const html = asciidoctor.convert(input, { extension_registry: registry, attributes: { 'kroki-fetch-diagram': true } })
-      expect(html).to.contain('<img src=".asciidoctor/kroki/hello-world.svg" alt="hello-world">')
+      expect(html).to.contain('<img src=".asciidoctor/kroki/diag-7a123c0b2909750ca5526554cd8620774ccf6cd9.svg" alt="hello-world">')
     })
     it('should download and save an image to a local folder and generated name', () => {
       const input = `
@@ -199,26 +199,6 @@ AsciiDoc -> HTML5: convert
         asciidoctorKroki.register(registry)
         const html = asciidoctor.convert(input, { extension_registry: registry, attributes: { 'kroki-fetch-diagram': true } })
         expect(html).to.contain('<img src=".asciidoctor/kroki/diag-ea85be88a0e4e5fb02f59602af7fe207feb5b904.svg" alt="diagram">')
-        expect(http.get.calledOnce).to.be.true()
-      } finally {
-        http.get.restore()
-      }
-    })
-    it('should not download twice the same image with target name', () => {
-      const input = `
-:imagesdir: .asciidoctor/kroki
-
-[plantuml,asciidoc-html5,svg,role=sequence]
-....
-AsciiDoc -> HTML5: convert
-....
-`
-      sinon.spy(http, 'get')
-      try {
-        const registry = asciidoctor.Extensions.create()
-        asciidoctorKroki.register(registry)
-        const html = asciidoctor.convert(input, { extension_registry: registry, attributes: { 'kroki-fetch-diagram': true } })
-        expect(html).to.contain('<img src=".asciidoctor/kroki/asciidoc-html5.svg" alt="asciidoc-html5">')
         expect(http.get.calledOnce).to.be.true()
       } finally {
         http.get.restore()


### PR DESCRIPTION
This reverts commit 00a8a69d32bb19939e151126802e04397ad6fd60.