### PR TITLE
Set path when updating the Antora content catalog

### DIFF
--- a/src/antora-adapter.js
+++ b/src/antora-adapter.js
@@ -17,6 +17,7 @@ module.exports = (file, contentCatalog, vfs) => {
             module,
             family: 'image',
             mediaType: image.mediaType,
+            path: image.relative + '/' + image.basename,
             basename: image.basename,
             relative: image.basename
           }

--- a/src/antora-adapter.js
+++ b/src/antora-adapter.js
@@ -1,3 +1,5 @@
+const ospath = require('path')
+
 module.exports = (file, contentCatalog, vfs) => {
   let baseReadFn
   if (typeof vfs === 'undefined' || typeof vfs.read !== 'function') {
@@ -17,7 +19,7 @@ module.exports = (file, contentCatalog, vfs) => {
             module,
             family: 'image',
             mediaType: image.mediaType,
-            path: image.relative + '/' + image.basename,
+            path: ospath.join(image.relative, image.basename),
             basename: image.basename,
             relative: image.basename
           }


### PR DESCRIPTION
People directly using the Antora content catalog (it's a long story :) ) may need the path set for consistency with the rest of the entries in there.

I'm not sure if it makes more sense to pass the full path around with the image, but in the interest of changing the least code, I've just added the path when setting the file in the content catalog.