### PR TITLE
resolves #104: Make compatible with asciidoctor 1.5.8 and Antora

### DIFF
--- a/src/antora-adapter.js
+++ b/src/antora-adapter.js
@@ -28,7 +28,7 @@ module.exports = (file, contentCatalog, vfs) => {
     },
     read: (resourceId, format) => {
       const target = contentCatalog.resolveResource(resourceId, file.src)
-      return target ? target.contents : baseReadFn(resourceId, format)
+      return target ? target.contents.toString() : baseReadFn(resourceId, format)
     }
   }
 }

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -99,7 +99,7 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
     block = processor.createImageBlock(parent, blockAttrs)
   }
   if (title) {
-    block.setTitle(title)
+    block['$title='](title)
   }
   block.$assign_caption(caption, 'figure')
   return block


### PR DESCRIPTION
This fixes the two compatibility issues with Antora; an asciidoctor 2 method and an assumption that the vfs read will return a String rather than a Buffer.