### PR TITLE
WIP resolves #109 Add kref support

### DIFF
--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -64,7 +64,9 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
   // Be careful not to specify "specialcharacters" or your diagram code won't be valid anymore!
   const subs = attrs.subs
   if (subs) {
+    context.diagramType = diagramType
     diagramText = parent.applySubstitutions(diagramText, parent.$resolve_subs(subs))
+    delete context.diagramType
   }
   if (diagramType === 'vegalite') {
     diagramText = require('./preprocess.js').preprocessVegaLite(diagramText, context)
@@ -186,9 +188,10 @@ function diagramBlockMacro (name, context) {
 }
 
 module.exports.register = function register (registry, context = {}) {
-  // patch context in case of Antora
+  // patch context in case of Antora. Also register kref
   if (typeof context.contentCatalog !== 'undefined' && typeof context.contentCatalog.addFile === 'function' && typeof context.file !== 'undefined') {
     context.vfs = require('./antora-adapter.js')(context.file, context.contentCatalog, context.vfs)
+    require('./kref/kref').register(registry, context)
   }
   const names = ['plantuml', 'ditaa', 'graphviz', 'blockdiag', 'seqdiag', 'actdiag', 'nwdiag', 'packetdiag', 'rackdiag', 'c4plantuml', 'erd', 'mermaid', 'nomnoml', 'svgbob', 'umlet', 'vega', 'vegalite', 'wavedrom', 'bytefield', 'bpmn']
   if (typeof registry.register === 'function') {

--- a/src/kref/compute-relative-url-path.js
+++ b/src/kref/compute-relative-url-path.js
@@ -1,0 +1,35 @@
+'use strict'
+//Copied from Antora. MPL 2.0 license
+
+const { posix: path } = require('path')
+
+/**
+ * Computes the shortest relative path between two URLs.
+ *
+ * This function takes into account directory index URLs and extensionless
+ * URLs. It assumes it's working with root-relative URLs, not qualified URLs
+ * with potentially different hosts.
+ *
+ * @memberof asciidoc-loader
+ *
+ * @param {String} from - The root-relative start URL.
+ * @param {String} to - The root-relative target URL.
+ * @param {String} [hash=''] - The URL hash to append to the URL (not #).
+ *
+ * @returns {String} The shortest relative path to travel from the start URL to the target URL.
+ */
+function computeRelativeUrlPath (from, to, hash = '') {
+  if (to.charAt() === '/') {
+    return to === from
+      ? hash || (isDir(to) ? './' : path.basename(to))
+      : (path.relative(path.dirname(from + '.'), to) || '.') + (isDir(to) ? '/' + hash : hash)
+  } else {
+    return to + hash
+  }
+}
+
+function isDir (str) {
+  return str.charAt(str.length - 1) === '/'
+}
+
+module.exports = computeRelativeUrlPath

--- a/src/kref/kref.js
+++ b/src/kref/kref.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const computeRelativeUrlPath = require('./compute-relative-url-path')
+
+const FORMATS = {
+  plantuml: (href, linkText) => `[[${href} ${linkText}]]`,
+}
+
+module.exports.register = function (registry, config_ = {}) {
+  // For a per-page extension in Antora, config will have the structure:
+  //{ file, // the vfs file being processed
+  // contentCatalog, // the Antora content catalog
+  // config // the asciidoc section of the playbook, enhanced with asciidoc attributes from the component descriptor.
+  // }
+
+  const { file, contentCatalog, config } = config_
+
+  const defaultFormat = config.attributes['kref-default-format'] || 'plantuml'
+
+  function antoraKrefInlineMacro () {
+    const self = this
+    self.named('kref')
+    self.positionalAttributes(['linkText', 'format'])
+    self.process(function (parent, target, attributes) {
+      var refSpec = target
+      var fragment
+      if (target.includes('#')) {
+        refSpec = target.slice(0, target.indexOf('#'))
+        fragment = target.slice(target.indexOf('#') + 1)
+      }
+      const targetFile = !refSpec ? file : contentCatalog.resolveResource(refSpec, file.src)
+      const href = computeRelativeUrlPath(file.pub.url, targetFile.pub.url, fragment ? '#' + fragment : '')
+      const linkText = attributes.linkText || fragment ? fragment : targetFile.asciidoc.attributes.doctitle
+      const format = FORMATS[config_.diagramType] || FORMATS[attributes.format] || FORMATS[defaultFormat]
+      const text = format(href, linkText)
+      // console.log('output text', text)
+      const result = self.createInline(parent, 'quoted', text)
+      result.setAttribute('subs', 'attributes')
+      return result
+    })
+  }
+
+  function doRegister (registry) {
+    if (typeof registry.inlineMacro === 'function') {
+      registry.inlineMacro(antoraKrefInlineMacro)
+    } else {
+      console.warn('no \'inlineMacro\' method on alleged registry')
+    }
+  }
+
+  if (typeof registry.register === 'function') {
+    registry.register(function () {
+      //Capture the global registry so processors can register more extensions.
+      registry = this
+      doRegister(registry)
+    })
+  } else {
+    doRegister(registry)
+  }
+  return registry
+}

--- a/src/kref/kref.js
+++ b/src/kref/kref.js
@@ -4,7 +4,8 @@ const computeRelativeUrlPath = require('./compute-relative-url-path')
 
 const FORMATS = {
   //https://stackoverflow.com/questions/14155773/label-hyperlink-graphviz
-  graphviz: (href, linkText) => `[${href}] [label="${linktext}"]`,
+  // graphviz: (href, linkText) => `[href="${href}"] [label="${linkText}"]`, // This seems to replace node names.
+  graphviz: (href, linkText) => `[href="${href}"]`,
   plantuml: (href, linkText) => `[[${href} ${linkText}]]`,
 }
 

--- a/src/kref/kref.js
+++ b/src/kref/kref.js
@@ -3,6 +3,10 @@
 const computeRelativeUrlPath = require('./compute-relative-url-path')
 
 const FORMATS = {
+  //https://bytefield-svg.deepsymmetry.org/bytefield-svg/1.5.0/funcs.html#wrap-link
+  // You need to construct part of this yourself, (wrap-link kref:index.adoc[]
+  //   (draw-box (text "length" [:math] [:sub 1]) {:span 4}))
+  bytefield: (href, linkText) => `"${href}"`,
   //https://stackoverflow.com/questions/14155773/label-hyperlink-graphviz
   // graphviz: (href, linkText) => `[href="${href}"] [label="${linkText}"]`, // This seems to replace node names.
   graphviz: (href, linkText) => `[href="${href}"]`,


### PR DESCRIPTION
Initial commit has minimal changes from @djencks/asciidoctor-antora-kref and installs the kref inline macro only when Antora is present.
The only additions are communicating the diagramType to the kref inline macro, and indexing formats on diagram type rather than format name.
This is not a finished product, but a basis for discussion and investigation.