### PR TITLE
Support for plantuml-config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,7 @@ Consult the [Kroki documentation](https://kroki.io/#support) to find out which f
 | `kroki-server-url` | The URL of the Kroki server (see "Using Your Own Kroki") | `https://kroki.io`
 | `kroki-fetch-diagram` | Define if we should download (and save on the disk) the images from the Kroki server.<br/>This feature is not available when running in the browser. | `false`
 | `kroki-http-method` | Define how we should get the image from the Kroki server. Possible values:<br/><ul><li>`get`: always use GET requests</li><li>`post`: always use POST requests</li><li>`adaptive`: use a POST request if the URI length is longer than 4096 characters, otherwise use a GET request</li></ul> | `adaptive` |
-| `kroki-plantuml-include` | A file that will be included at the top of all PlantUML diagrams as if `!include file` was used. This allows you to define a common skin for your diagrams. This can be a path or a URL. |  |
-
+| `kroki-plantuml-include` | A file that will be included at the top of all PlantUML diagrams as if `!include file` was used. This can be useful when you want to define a common skin for all your diagrams. The value can be a path or a URL. |  |
 ### Default configuration
 
 By default, images are generated as SVG when possible.

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Consult the [Kroki documentation](https://kroki.io/#support) to find out which f
 | `kroki-server-url` | The URL of the Kroki server (see "Using Your Own Kroki") | `https://kroki.io`
 | `kroki-fetch-diagram` | Define if we should download (and save on the disk) the images from the Kroki server.<br/>This feature is not available when running in the browser. | `false`
 | `kroki-http-method` | Define how we should get the image from the Kroki server. Possible values:<br/><ul><li>`get`: always use GET requests</li><li>`post`: always use POST requests</li><li>`adaptive`: use a POST request if the URI length is longer than 4096 characters, otherwise use a GET request</li></ul> | `adaptive` |
-| `kroki-plantuml-config` | A file that will be included at the top of all PlantUML diagrams. This allows you to define a common skin for your diagrams. This can be a path or a URL. |  |
+| `kroki-plantuml-include` | A file that will be included at the top of all PlantUML diagrams as if `!include file` was used. This allows you to define a common skin for your diagrams. This can be a path or a URL. |  |
 
 ### Default configuration
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Consult the [Kroki documentation](https://kroki.io/#support) to find out which f
 | `kroki-server-url` | The URL of the Kroki server (see "Using Your Own Kroki") | `https://kroki.io`
 | `kroki-fetch-diagram` | Define if we should download (and save on the disk) the images from the Kroki server.<br/>This feature is not available when running in the browser. | `false`
 | `kroki-http-method` | Define how we should get the image from the Kroki server. Possible values:<br/><ul><li>`get`: always use GET requests</li><li>`post`: always use POST requests</li><li>`adaptive`: use a POST request if the URI length is longer than 4096 characters, otherwise use a GET request</li></ul> | `adaptive` |
+| `kroki-plantuml-config` | A file that will be included at the top of all PlantUML diagrams. This allows you to define a common skin for your diagrams. This can be a path or a URL. |  |
 
 ### Default configuration
 

--- a/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
+++ b/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
@@ -76,8 +76,8 @@ module AsciidoctorExtensions
       private
 
       def prepend_plantuml_config(diagram_text, diagram_type, doc)
-        if diagram_type == :plantuml && doc.attributes['kroki-plantuml-config']
-          config = File.read(doc.attributes['kroki-plantuml-config'])
+        if diagram_type == :plantuml && doc.attributes['kroki-plantuml-include']
+          config = File.read(doc.attributes['kroki-plantuml-include'])
           diagram_text = config + '\n' + diagram_text
         end
         diagram_text

--- a/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
+++ b/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
@@ -52,6 +52,7 @@ module AsciidoctorExtensions
     class << self
       def process(processor, parent, attrs, diagram_type, diagram_text)
         doc = parent.document
+        diagram_text = prepend_plantuml_config(diagram_text, diagram_type, doc)
         # If "subs" attribute is specified, substitute accordingly.
         # Be careful not to specify "specialcharacters" or your diagram code won't be valid anymore!
         if (subs = attrs['subs'])
@@ -73,6 +74,14 @@ module AsciidoctorExtensions
       end
 
       private
+
+      def prepend_plantuml_config(diagram_text, diagram_type, doc)
+        if diagram_type == :plantuml && doc.attributes['kroki-plantuml-config']
+          config = File.read(doc.attributes['kroki-plantuml-config'])
+          diagram_text = config + '\n' + diagram_text
+        end
+        diagram_text
+      end
 
       def get_alt(attrs)
         if (title = attrs['title'])

--- a/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
+++ b/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
@@ -76,8 +76,10 @@ module AsciidoctorExtensions
       private
 
       def prepend_plantuml_config(diagram_text, diagram_type, doc)
-        if diagram_type == :plantuml && doc.attributes['kroki-plantuml-include']
-          config = File.read(doc.attributes['kroki-plantuml-include'])
+        if diagram_type == :plantuml && doc.attr?('kroki-plantuml-include')
+          # TODO: this behaves different than the JS version
+          # The file should be added by !include #{plantuml_include}" once we have a preprocessor for ruby
+          config = File.read(doc.attr('kroki-plantuml-include'))
           diagram_text = config + '\n' + diagram_text
         end
         diagram_text

--- a/ruby/spec/asciidoctor_kroki_spec.rb
+++ b/ruby/spec/asciidoctor_kroki_spec.rb
@@ -33,5 +33,19 @@ describe ::AsciidoctorExtensions::KrokiBlockProcessor do
 </div>
 </div>)
     end
+    it 'should include the plantuml-config file' do
+      input = <<~'ADOC'
+        [plantuml]
+        ....
+        alice -> bob: hello
+        ....
+      ADOC
+      output = Asciidoctor.convert(input, attributes: { 'env-idea' => '', 'kroki-plantuml-config' => 'spec/fixtures/config.puml' }, standalone: false)
+      (expect output).to eql %(<div class="imageblock kroki">
+<div class="content">
+<img src="https://kroki.io/plantuml/png/eNorzs7MK0gsSsxVyM3Py0_OKMrPTVUoKSpN5YrJS8zJTE5V0LVTSMpPslLISM3JyQcArVsRHA==" alt="Diagram">
+</div>
+</div>)
+    end
   end
 end

--- a/ruby/spec/asciidoctor_kroki_spec.rb
+++ b/ruby/spec/asciidoctor_kroki_spec.rb
@@ -33,14 +33,14 @@ describe ::AsciidoctorExtensions::KrokiBlockProcessor do
 </div>
 </div>)
     end
-    it 'should include the plantuml-config file' do
+    it 'should include the plantuml-include file' do
       input = <<~'ADOC'
         [plantuml]
         ....
         alice -> bob: hello
         ....
       ADOC
-      output = Asciidoctor.convert(input, attributes: { 'env-idea' => '', 'kroki-plantuml-config' => 'spec/fixtures/config.puml' }, standalone: false)
+      output = Asciidoctor.convert(input, attributes: { 'env-idea' => '', 'kroki-plantuml-include' => 'spec/fixtures/config.puml' }, standalone: false)
       (expect output).to eql %(<div class="imageblock kroki">
 <div class="content">
 <img src="https://kroki.io/plantuml/png/eNorzs7MK0gsSsxVyM3Py0_OKMrPTVUoKSpN5YrJS8zJTE5V0LVTSMpPslLISM3JyQcArVsRHA==" alt="Diagram">

--- a/ruby/spec/fixtures/config.puml
+++ b/ruby/spec/fixtures/config.puml
@@ -1,0 +1,1 @@
+skinparam monochrome true

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -69,9 +69,9 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
   if (diagramType === 'vegalite') {
     diagramText = require('./preprocess.js').preprocessVegaLite(diagramText, context)
   } else if (diagramType === 'plantuml') {
-    const plantUMLConfig = doc.getAttribute('kroki-plantuml-config')
-    if (plantUMLConfig) {
-      diagramText = `!include ${plantUMLConfig}\n${diagramText}`
+    const plantUmlInclude = doc.getAttribute('kroki-plantuml-include')
+    if (plantUmlInclude) {
+      diagramText = `!include ${plantUmlInclude}\n${diagramText}`
     }
     diagramText = require('./preprocess.js').preprocessPlantUML(diagramText, context, doc.getBaseDir())
   }

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -69,6 +69,10 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
   if (diagramType === 'vegalite') {
     diagramText = require('./preprocess.js').preprocessVegaLite(diagramText, context)
   } else if (diagramType === 'plantuml') {
+    const plantUMLConfig = doc.getAttribute('kroki-plantuml-config')
+    if (plantUMLConfig) {
+      diagramText = `!include ${plantUMLConfig}\n${diagramText}`
+    }
     diagramText = require('./preprocess.js').preprocessPlantUML(diagramText, context, doc.getBaseDir())
   }
   const blockId = attrs.id

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -101,6 +101,16 @@ plantuml::test/fixtures/alice.puml[svg,role=sequence]
       const hash = rusha.createHash().update(`https://kroki.io/plantuml/svg/${encode(file)}`).digest('hex')
       expect(html).to.contain(`<img src=".asciidoctor/kroki/diag-${hash}.svg" alt="Diagram">`)
     }).timeout(5000)
+    it('should include the plantuml-config at the top of the diagram', () => {
+      const file = `${__dirname}/fixtures/alice.puml`
+      const config = `${__dirname}/fixtures/plantuml/base.iuml`
+      const input = `plantuml::${file}[svg,role=sequence]`
+      const registry = asciidoctor.Extensions.create()
+      asciidoctorKroki.register(registry)
+      const html = asciidoctor.convert(input, { extension_registry: registry, attributes: { 'kroki-plantuml-config': config } })
+      expect(html).to.contain('https://kroki.io/plantuml/svg/eNo9yjsOgCAMANCdUzTsXsEQNY7coUBVQqGGz_1lcn15LcXyYsUMB104uJ9SusVMoC0N_6BW7S8b-nRXGSXswlLB8QRlWsfaR2aFHD3BsoITpwyVMPED1gEjAw==')
+      expect(html).to.contain('<div class="imageblock sequence kroki-format-svg kroki">')
+    }).timeout(5000)
     it('should convert a file containing the macro form using a relative path to a diagram', () => {
       const registry = asciidoctor.Extensions.create()
       asciidoctorKroki.register(registry)

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -114,7 +114,7 @@ plantuml::test/fixtures/alice.puml[svg,role=sequence]
       const input = `plantuml::${file}[svg,role=sequence]`
       const registry = asciidoctor.Extensions.create()
       asciidoctorKroki.register(registry)
-      const html = asciidoctor.convert(input, { extension_registry: registry, attributes: { 'kroki-plantuml-config': config } })
+      const html = asciidoctor.convert(input, { extension_registry: registry, attributes: { 'kroki-plantuml-include': config } })
       const diagramText = getDiagramFromHTML(html)
       expect(diagramText).to.contain('skinparam BackgroundColor black')
       expect(diagramText).to.contain('alice -> bob')

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -51,6 +51,13 @@ describe('Conversion', () => {
       .replace(/\//g, '_')
   }
 
+  function getDiagramFromHTML (html) {
+    const diagrams = html.match(/(?<="https:\/\/kroki\.io\/plantuml\/svg\/)[^"]+/g)
+    if (diagrams) {
+      return pako.inflate(Buffer.from(diagrams[0], 'base64'), { to: 'string' })
+    }
+  }
+
   describe('When extension is registered', () => {
     it('should convert a diagram to an image', () => {
       const input = `
@@ -108,7 +115,9 @@ plantuml::test/fixtures/alice.puml[svg,role=sequence]
       const registry = asciidoctor.Extensions.create()
       asciidoctorKroki.register(registry)
       const html = asciidoctor.convert(input, { extension_registry: registry, attributes: { 'kroki-plantuml-config': config } })
-      expect(html).to.contain('https://kroki.io/plantuml/svg/eNo9yjsOgCAMANCdUzTsXsEQNY7coUBVQqGGz_1lcn15LcXyYsUMB104uJ9SusVMoC0N_6BW7S8b-nRXGSXswlLB8QRlWsfaR2aFHD3BsoITpwyVMPED1gEjAw==')
+      const diagramText = getDiagramFromHTML(html)
+      expect(diagramText).to.contain('skinparam BackgroundColor black')
+      expect(diagramText).to.contain('alice -> bob')
       expect(html).to.contain('<div class="imageblock sequence kroki-format-svg kroki">')
     }).timeout(5000)
     it('should convert a file containing the macro form using a relative path to a diagram', () => {


### PR DESCRIPTION
This adds a new param for a common config for all plantuml diagrams.
The config will be added to the top of the diagram. It allows users to define a common skin.

resolves #118 