### PR TITLE
Lack of local includes should only warn

### DIFF
--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -195,8 +195,9 @@ function readPlantUmlInclude (url, dirPath, includeStack, vfs) {
         try {
           text = read(filePath)
         } catch (e) {
-          const message = `Preprocessing of PlantUML include failed, because reading the referenced local file '${filePath}' caused an error:\n${e}`
-          throw addCauseToError(new Error(message), e)
+          // Only warn and do not throw an error, because the data file can perhaps be found by kroki server
+          console.warn(`Skipping preprocessing of PlantUML include, because reading the referenced local file '${filePath}' caused an error:\n${e}`)
+          skip = true
         }
       }
     }

--- a/test/preprocess.spec.js
+++ b/test/preprocess.spec.js
@@ -109,13 +109,11 @@ describe('PlantUML preprocessing', () => {
     expect(preprocessPlantUML(diagramTextWithStdLibIncludeFile, {})).to.be.equal(diagramTextWithStdLibIncludeFile)
   })
 
-  it('should throw an error for unexisting local file referenced with "!include local-file-or-url"', () => {
+  it('should warn and return original diagramText for unexisting local file referenced with "!include local-file-or-url", because it can perhaps be found by kroki server', () => {
     const diagramTextWithUnexistingLocalIncludeFile = `
       !include ${localUnexistingFilePath}
       alice -> bob`
-    const errorMessage = `Preprocessing of PlantUML include failed, because reading the referenced local file '${localUnexistingFilePath}' caused an error:
-Error: ENOENT: no such file or directory, open '${localUnexistingFilePath}'`
-    expect(() => preprocessPlantUML(diagramTextWithUnexistingLocalIncludeFile, {})).to.throw(errorMessage)
+    expect(preprocessPlantUML(diagramTextWithUnexistingLocalIncludeFile, {})).to.be.equal(diagramTextWithUnexistingLocalIncludeFile)
   })
 
   it('should warn and return original diagramText for unexisting remote file referenced with "!include remote-url", because it can perhaps be found by kroki server', () => {


### PR DESCRIPTION
Lack of local includes should only warn and do not throw an error, because the data file can perhaps be found by kroki server.

This changes local files pre-processing to be best-effort. And reverts behavior to as in 0.8.2 version.  