### PR TITLE
resolves #144 add an entrypoint

### DIFF
--- a/ruby/lib/asciidoctor-kroki.rb
+++ b/ruby/lib/asciidoctor-kroki.rb
@@ -1,0 +1,5 @@
+# rubocop:disable Naming/FileName
+# rubocop:enable Naming/FileName
+# frozen_string_literal: true
+
+require_relative 'asciidoctor/extensions/asciidoctor_kroki'

--- a/ruby/spec/require_spec.rb
+++ b/ruby/spec/require_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe 'require' do
+  it 'should require the library' do
+    lib = File.expand_path('lib', __dir__)
+    $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+    require 'asciidoctor-kroki'
+
+    (expect Asciidoctor::Extensions.groups[:extgrp0]).to_not be_nil
+  end
+end


### PR DESCRIPTION
Otherwise Ruby cannot resolve the lib when using `require 'asciidoctor-kroki'`.

resolves #144