### PR TITLE
Local data file referenced relatively in Vega-Lite file

### DIFF
--- a/dist/browser/asciidoctor-kroki.js
+++ b/dist/browser/asciidoctor-kroki.js
@@ -18266,7 +18266,7 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
     diagramText = parent.applySubstitutions(diagramText, parent.$resolve_subs(subs))
   }
   if (diagramType === 'vegalite') {
-    diagramText = require('./preprocess.js').preprocessVegaLite(diagramText, context)
+    diagramText = require('./preprocess.js').preprocessVegaLite(diagramText, context, doc.getBaseDir())
   } else if (diagramType === 'plantuml') {
     const plantUmlInclude = doc.getAttribute('kroki-plantuml-include')
     if (plantUmlInclude) {
@@ -18554,15 +18554,18 @@ module.exports.KrokiClient = class KrokiClient {
 
 }).call(this)}).call(this,require("buffer").Buffer)
 },{"buffer":3,"pako":9}],63:[function(require,module,exports){
+// @ts-check
+// The previous line must be the first non-comment line in the file to enable TypeScript checks:
+// https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check
 const path = require('path')
 
-// @ts-check
 /**
  * @param {string} diagramText
  * @param {any} context
+ * @param {string} baseDir
  * @returns {string}
  */
-module.exports.preprocessVegaLite = function (diagramText, context) {
+module.exports.preprocessVegaLite = function (diagramText, context, baseDir = '') {
   let diagramObject
   try {
     const JSON5 = require('json5')
@@ -18582,15 +18585,16 @@ ${diagramText}
   const vfs = context.vfs
   const read = typeof vfs !== 'undefined' && typeof vfs.read === 'function' ? vfs.read : require('./node-fs.js').read
   const data = diagramObject.data
+  const urlOrPath = data.url
   try {
-    data.values = read(data.url)
+    data.values = read(isLocalAndRelative(urlOrPath) ? baseDir + urlOrPath : urlOrPath)
   } catch (e) {
-    if (isRemoteUrl(data.url)) {
+    if (isRemoteUrl(urlOrPath)) {
       // Only warn and do not throw an error, because the data file can perhaps be found by kroki server (https://github.com/yuzutech/kroki/issues/60)
-      console.warn(`Skipping preprocessing of Vega-Lite view specification, because reading the referenced remote file '${data.url}' caused an error:\n${e}`)
+      console.warn(`Skipping preprocessing of Vega-Lite view specification, because reading the remote data file '${urlOrPath}' referenced in the diagram caused an error:\n${e}`)
       return diagramText
     }
-    const message = `Preprocessing of Vega-Lite view specification failed, because reading the referenced local file '${data.url}' caused an error:\n${e}`
+    const message = `Preprocessing of Vega-Lite view specification failed, because reading the local data file '${urlOrPath}' referenced in the diagram caused an error:\n${e}`
     throw addCauseToError(new Error(message), e)
   }
 
@@ -18802,7 +18806,7 @@ function getPlantUmlTextRegEx (text, regEx) {
 
 /**
  * @param {string} text
- * @param {int} index
+ * @param {number} index
  * @returns {string}
  */
 function getPlantUmlTextFromIndex (text, index) {
@@ -18870,6 +18874,25 @@ function isRemoteUrl (string) {
     return url.protocol !== 'file:'
   } catch (_) {
     return false
+  }
+}
+
+/**
+ * @param {string} string
+ * @returns {boolean}
+ */
+function isLocalAndRelative (string) {
+  if (string.startsWith('/')) {
+    return false
+  }
+
+  try {
+    // eslint-disable-next-line no-new
+    new URL(string)
+    // A URL can not be local AND relative: https://stackoverflow.com/questions/7857416/file-uri-scheme-and-relative-files
+    return false
+  } catch (_) {
+    return true
   }
 }
 

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -58,7 +58,7 @@ function getOption (attrs, document) {
   }
 }
 
-const processKroki = (processor, parent, attrs, diagramType, diagramText, context, baseDir) => {
+const processKroki = (processor, parent, attrs, diagramType, diagramText, context) => {
   const doc = parent.getDocument()
   // If "subs" attribute is specified, substitute accordingly.
   // Be careful not to specify "specialcharacters" or your diagram code won't be valid anymore!
@@ -67,7 +67,7 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
     diagramText = parent.applySubstitutions(diagramText, parent.$resolve_subs(subs))
   }
   if (diagramType === 'vegalite') {
-    diagramText = require('./preprocess.js').preprocessVegaLite(diagramText, context, baseDir)
+    diagramText = require('./preprocess.js').preprocessVegaLite(diagramText, context, doc.getBaseDir())
   } else if (diagramType === 'plantuml') {
     const plantUmlInclude = doc.getAttribute('kroki-plantuml-include')
     if (plantUmlInclude) {
@@ -176,8 +176,7 @@ function diagramBlockMacro (name, context) {
       const diagramType = name
       try {
         const diagramText = vfs.read(target)
-        const baseDir = parent.getDocument().getBaseDir()
-        return processKroki(this, parent, attrs, diagramType, diagramText, context, baseDir)
+        return processKroki(this, parent, attrs, diagramType, diagramText, context)
       } catch (e) {
         console.warn(`Skipping ${diagramType} block macro. ${e.message}`)
         attrs.role = role ? `${role} kroki-error` : 'kroki-error'

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -176,7 +176,7 @@ function diagramBlockMacro (name, context) {
       const diagramType = name
       try {
         const diagramText = vfs.read(target)
-        const baseDir = target.substr(0, target.lastIndexOf('/') + 1)
+        const baseDir = parent.getDocument().getBaseDir()
         return processKroki(this, parent, attrs, diagramType, diagramText, context, baseDir)
       } catch (e) {
         console.warn(`Skipping ${diagramType} block macro. ${e.message}`)

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -58,7 +58,7 @@ function getOption (attrs, document) {
   }
 }
 
-const processKroki = (processor, parent, attrs, diagramType, diagramText, context) => {
+const processKroki = (processor, parent, attrs, diagramType, diagramText, context, baseDir) => {
   const doc = parent.getDocument()
   // If "subs" attribute is specified, substitute accordingly.
   // Be careful not to specify "specialcharacters" or your diagram code won't be valid anymore!
@@ -67,7 +67,7 @@ const processKroki = (processor, parent, attrs, diagramType, diagramText, contex
     diagramText = parent.applySubstitutions(diagramText, parent.$resolve_subs(subs))
   }
   if (diagramType === 'vegalite') {
-    diagramText = require('./preprocess.js').preprocessVegaLite(diagramText, context)
+    diagramText = require('./preprocess.js').preprocessVegaLite(diagramText, context, baseDir)
   } else if (diagramType === 'plantuml') {
     const plantUmlInclude = doc.getAttribute('kroki-plantuml-include')
     if (plantUmlInclude) {
@@ -176,7 +176,8 @@ function diagramBlockMacro (name, context) {
       const diagramType = name
       try {
         const diagramText = vfs.read(target)
-        return processKroki(this, parent, attrs, diagramType, diagramText, context)
+        const baseDir = target.substr(0, target.lastIndexOf('/') + 1)
+        return processKroki(this, parent, attrs, diagramType, diagramText, context, baseDir)
       } catch (e) {
         console.warn(`Skipping ${diagramType} block macro. ${e.message}`)
         attrs.role = role ? `${role} kroki-error` : 'kroki-error'

--- a/src/node-fs.js
+++ b/src/node-fs.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const mkdirp = require('mkdirp')
+const url = require('url')
 
 const http = require('./http/node-http.js')
 
@@ -18,7 +19,7 @@ module.exports = {
       return http.get(path, encoding)
     }
     if (path.startsWith('file://')) {
-      return fs.readFileSync(path.substr('file://'.length), encoding)
+      return fs.readFileSync(url.fileURLToPath(path), encoding)
     }
     return fs.readFileSync(path, encoding)
   }

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -1,12 +1,15 @@
+// @ts-check
+// The previous line must be the first non-comment line in the file to enable TypeScript checks:
+// https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check
 const path = require('path')
 
-// @ts-check
 /**
  * @param {string} diagramText
  * @param {any} context
+ * @param {string} baseDir
  * @returns {string}
  */
-module.exports.preprocessVegaLite = function (diagramText, context) {
+module.exports.preprocessVegaLite = function (diagramText, context, baseDir = '') {
   let diagramObject
   try {
     const JSON5 = require('json5')
@@ -26,15 +29,16 @@ ${diagramText}
   const vfs = context.vfs
   const read = typeof vfs !== 'undefined' && typeof vfs.read === 'function' ? vfs.read : require('./node-fs.js').read
   const data = diagramObject.data
+  const urlOrPath = data.url
   try {
-    data.values = read(data.url)
+    data.values = read(isLocalAndRelative(urlOrPath) ? baseDir + urlOrPath : urlOrPath)
   } catch (e) {
-    if (isRemoteUrl(data.url)) {
+    if (isRemoteUrl(urlOrPath)) {
       // Only warn and do not throw an error, because the data file can perhaps be found by kroki server (https://github.com/yuzutech/kroki/issues/60)
-      console.warn(`Skipping preprocessing of Vega-Lite view specification, because reading the referenced remote file '${data.url}' caused an error:\n${e}`)
+      console.warn(`Skipping preprocessing of Vega-Lite view specification, because reading the remote data file '${urlOrPath}' referenced in the diagram caused an error:\n${e}`)
       return diagramText
     }
-    const message = `Preprocessing of Vega-Lite view specification failed, because reading the referenced local file '${data.url}' caused an error:\n${e}`
+    const message = `Preprocessing of Vega-Lite view specification failed, because reading the local data file '${urlOrPath}' referenced in the diagram caused an error:\n${e}`
     throw addCauseToError(new Error(message), e)
   }
 
@@ -249,7 +253,7 @@ function getPlantUmlTextRegEx (text, regEx) {
 
 /**
  * @param {string} text
- * @param {int} index
+ * @param {number} index
  * @returns {string}
  */
 function getPlantUmlTextFromIndex (text, index) {
@@ -321,5 +325,24 @@ function isRemoteUrl (string) {
     return url.protocol !== 'file:'
   } catch (_) {
     return false
+  }
+}
+
+/**
+ * @param {string} string
+ * @returns {boolean}
+ */
+function isLocalAndRelative (string) {
+  if (string.startsWith('/')) {
+    return false
+  }
+
+  try {
+    // eslint-disable-next-line no-new
+    new URL(string)
+    // A URL can not be local AND relative: https://stackoverflow.com/questions/7857416/file-uri-scheme-and-relative-files
+    return false
+  } catch (_) {
+    return true
   }
 }

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -31,7 +31,7 @@ ${diagramText}
   const data = diagramObject.data
   const urlOrPath = data.url
   try {
-    data.values = read(isLocalAndRelative(urlOrPath) ? baseDir + urlOrPath : urlOrPath)
+    data.values = read(isLocalAndRelative(urlOrPath) ? path.join(baseDir, urlOrPath) : urlOrPath)
   } catch (e) {
     if (isRemoteUrl(urlOrPath)) {
       // Only warn and do not throw an error, because the data file can perhaps be found by kroki server (https://github.com/yuzutech/kroki/issues/60)

--- a/test/preprocess.spec.js
+++ b/test/preprocess.spec.js
@@ -44,7 +44,7 @@ describe('Vega-Lite preprocessing', () => {
    * @returns {void}
    */
   function expectToBeEqual (diagramText, expectedPreprocessedDiagramText, baseDir) {
-    expect(preprocessVegaLite(diagramText, {}, baseDir).replace(/\r\n/g, '\n')).to.be.equal(expectedPreprocessedDiagramText)
+    expect(preprocessVegaLite(diagramText, {}, baseDir)).to.be.equal(expectedPreprocessedDiagramText.replace(/\r\n/g, '\n'))
   }
 
   it('should throw an error for invalid JSON', () => {

--- a/test/preprocess.spec.js
+++ b/test/preprocess.spec.js
@@ -20,7 +20,7 @@ describe('Vega-Lite preprocessing', () => {
   const relativePath = 'test/fixtures/vegalite-data.csv'
   const diagramTextWithInlinedCsvFile = JSON.stringify({
     data: {
-      values: fs.readFileSync(`${__dirname}/fixtures/vegalite-data.csv`, 'utf8'),
+      values: fs.readFileSync(`${path.join(cwd, relativePath)}`, 'utf8'),
       format: {
         type: 'csv'
       }
@@ -71,7 +71,7 @@ Error: ENOENT: no such file or directory, open 'unexisting.csv'`
   })
 
   it('should throw an error for unexisting file referenced with "file" protocol', () => {
-    const unexistingFileUrl = url.pathToFileURL(cwd + '/unexisting.csv')
+    const unexistingFileUrl = url.pathToFileURL(path.join(cwd, 'unexisting.csv'))
     const diagramText = `{
       "data": {
         "url": "${unexistingFileUrl}"

--- a/test/preprocess.spec.js
+++ b/test/preprocess.spec.js
@@ -144,7 +144,9 @@ Error: ENOENT: no such file or directory, open '${unexistingPath}'`
     "url": "https://raw.githubusercontent.com/Mogztter/asciidoctor-kroki/master/${relativePath}"
   }
 }`
-    expectToBeEqual(diagramText, diagramTextWithInlinedCsvFile)
+    // replace escaped CR/LF (which happens when CSV file was checked-out in Windows) with escaped LF
+    const expected = diagramTextWithInlinedCsvFile.replace(/\\r\\n/g, '\\n')
+    expectToBeEqual(diagramText, expected)
   })
 })
 

--- a/test/preprocess.spec.js
+++ b/test/preprocess.spec.js
@@ -44,7 +44,7 @@ describe('Vega-Lite preprocessing', () => {
    * @returns {void}
    */
   function expectToBeEqual (diagramText, expectedPreprocessedDiagramText, baseDir) {
-    expect(preprocessVegaLite(diagramText, {}, baseDir)).to.be.equal(expectedPreprocessedDiagramText)
+    expect(preprocessVegaLite(diagramText, {}, baseDir).replace(/\r\n/g, '\n')).to.be.equal(expectedPreprocessedDiagramText)
   }
 
   it('should throw an error for invalid JSON', () => {


### PR DESCRIPTION
fixes #114
fixes file URLs in Windows

Could you please have a look at this PR? 

This fixes an inconsistency if the Vega-Lite file is in a different directory than the Asciidoctor file and references a local data file. This does not fix a similar problem for PlantUML (which should probably also be fixed, as you proposed).

This fixes also a problem with file URLs, which I had in Windows (see `node-fs.js`). This could change existing behavior globally and not only for Vega-Lite diagrams!

In addition, I did some refactorings especially in the test code and moved `// @ts-node` back to the beginning of the file.

BTW: As I have some time at the moment (I regret that I did not have it earlier), I hope to fix #98 and #99 soon, which will be easier for me once this PR is merged.

