### PR TITLE
Ruby: change the encoded newline to a real newline for kroki-plantuml-include

### DIFF
--- a/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
+++ b/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
@@ -117,7 +117,7 @@ module AsciidoctorExtensions
           # TODO: this behaves different than the JS version
           # The file should be added by !include #{plantuml_include}" once we have a preprocessor for ruby
           config = File.read(doc.attr('kroki-plantuml-include'))
-          diagram_text = config + '\n' + diagram_text
+          diagram_text = config + "\n" + diagram_text
         end
         diagram_text
       end

--- a/ruby/spec/asciidoctor_kroki_spec.rb
+++ b/ruby/spec/asciidoctor_kroki_spec.rb
@@ -44,7 +44,7 @@ describe ::AsciidoctorExtensions::KrokiBlockProcessor do
       output = Asciidoctor.convert(input, attributes: { 'env-idea' => '', 'kroki-plantuml-include' => 'spec/fixtures/config.puml' }, standalone: false)
       (expect output).to eql %(<div class="imageblock kroki">
 <div class="content">
-<img src="https://kroki.io/plantuml/png/eNorzs7MK0gsSsxVyM3Py0_OKMrPTVUoKSpN5YrJS8zJTE5V0LVTSMpPslLISM3JyQcArVsRHA==" alt="Diagram">
+<img src="https://kroki.io/plantuml/png/eNorzs7MK0gsSsxVyM3Py0_OKMrPTVUoKSpN5eJKzMlMTlXQtVNIyk-yUshIzcnJBwCT9xBc" alt="Diagram">
 </div>
 </div>)
     end


### PR DESCRIPTION
... as it would otherwise break the content. 

It seems that the generated URL by accident produces a SVG - although the meaning has been changed. 

Image before (wrong): 

![image](https://user-images.githubusercontent.com/3957921/105231307-f4fdd600-5b66-11eb-82cf-a6fab7b6c22c.png)

Decoding the contents of the URL shows the surplus `\n` at the beginning of the line: 

```
skinparam monochrome true
\nalice -> bob: hello
```

Image after (correct): 

![image](https://user-images.githubusercontent.com/3957921/105231359-0ba42d00-5b67-11eb-9411-e8eb2b2f98d7.png)
