### PR TITLE
match "lf" line endings in .editorconfig for .gitattributes and rubocop

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# To match the .editorconfig that asks for lf only
+# Otherwise you will end up with files that show up as modified after you IDE
+* text=auto eol=lf

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,6 +1,9 @@
 Style/Encoding:
   Enabled: false
 
+Layout/EndOfLine:
+  EnforcedStyle: lf
+
 Metrics/LineLength:
   Max: 160
 


### PR DESCRIPTION
Working with an OS that is notoriously known for its CRLF line endings, I found myself in the following situation: 

* git checked out all files with CRLF
* .editorconfig asked my IDE to safe all changed files with LF
* rubocop complained about LF files, as it used the OS default

Therefore I suggest to align the settings of git and rubocop with the .editorconfig. 

