### PR TITLE
Ruby: fix spelling of wavedrom

### DIFF
--- a/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
+++ b/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
@@ -70,7 +70,7 @@ module AsciidoctorExtensions
       umlet
       vega
       vegalite
-      wavedrow
+      wavedrom
     ].freeze
   end
 

--- a/ruby/spec/asciidoctor_kroki_spec.rb
+++ b/ruby/spec/asciidoctor_kroki_spec.rb
@@ -80,7 +80,7 @@ end
 describe ::AsciidoctorExtensions::Kroki do
   it 'should return the list of supported diagrams' do
     diagram_names = ::AsciidoctorExtensions::Kroki::SUPPORTED_DIAGRAM_NAMES
-    expect(diagram_names).to include('vegalite', 'plantuml', 'bytefield', 'bpmn', 'excalidraw')
+    expect(diagram_names).to include('vegalite', 'plantuml', 'bytefield', 'bpmn', 'excalidraw', 'wavedrom')
   end
   it 'should register the extension for the list of supported diagrams' do
     doc = Asciidoctor::Document.new


### PR DESCRIPTION
This problem seems to be introduced by commit 3dfc3154f8017fdc4eaba17c33052859dce6e852