### PR TITLE
resolves #277 Post request bug correction

### DIFF
--- a/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
+++ b/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
@@ -377,7 +377,7 @@ module AsciidoctorExtensions
       end
 
       def post(uri, data, _)
-        res = ::Net::HTTP.post(URI(uri), data, "Content-Type" => "text/plain")
+        res = ::Net::HTTP.post(URI(uri), data, 'Content-Type' => 'text/plain')
         res.body
       end
     end


### PR DESCRIPTION
Fix  issue #277 
asciidoctor: FAILED: documentation/Figures.adoc: Failed to load AsciiDoc document - undefined method `request_post' for Net::HTTP:Class
