### PR TITLE
Route logs through the Asciidoctor logger

### DIFF
--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -1,3 +1,4 @@
+/* global Opal */
 // @ts-check
 const { KrokiDiagram, KrokiClient } = require('./kroki-client.js')
 
@@ -198,6 +199,7 @@ module.exports.register = function register (registry, context = {}) {
   if (typeof context.contentCatalog !== 'undefined' && typeof context.contentCatalog.addFile === 'function' && typeof context.file !== 'undefined') {
     context.vfs = require('./antora-adapter.js')(context.file, context.contentCatalog, context.vfs)
   }
+  context.logger = Opal.Asciidoctor.LoggerManager.getLogger()
   const names = [
     'actdiag',
     'blockdiag',

--- a/test/antora/docs/modules/ROOT/pages/topic/index.adoc
+++ b/test/antora/docs/modules/ROOT/pages/topic/index.adoc
@@ -43,3 +43,22 @@ include::example$ab-all.puml[]
 ----
 include::example$ab.puml[]
 ----
+
+== C4 Diagram with !include
+
+[c4plantuml]
+----
+@startuml
+!include <C4/C4_Container>
+
+Person(personAlias, "Label", "Optional Description")
+Container(containerAlias, "Label", "Technology", "Optional Description")
+System(systemAlias, "Label", "Optional Description")
+
+System_Ext(extSystemAlias, "Label", "Optional Description")
+
+Rel(personAlias, containerAlias, "Label", "Optional Technology")
+
+Rel_U(systemAlias, extSystemAlias, "Label", "Optional Technology")
+@enduml
+----


### PR DESCRIPTION
- Reduce log severity to info (previously was warn)


Here's an example when running Antora 3:

```console
$ npx antora --log-level=info site.yml
[15:05:03.622] INFO (asciidoctor): Skipping preprocessing of PlantUML standard library include '<C4/C4_Container>'
    file: /path/to/dir/docs/modules/ROOT/pages/topic/index.adoc
    source: /path/to/dir (refname: main <worktree>, start path: docs)
 ```

Ref #147 