### PR TITLE
resolves #379 support windows EOL line endings

### DIFF
--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -124,7 +124,7 @@ function preprocessPlantUmlIncludes (diagramText, dirPath, includeOnce, includeS
           const target = parseTarget(args[1])
           const urlSub = target.url.split('!')
           const trailingContent = target.comment
-          const url = urlSub[0].replace(/\\ /g, ' ')
+          const url = urlSub[0].replace(/\\ /g, ' ').replace(/(\r\n|\n|\r|\s*)$/mg, '')
           const sub = urlSub[1]
           const result = readPlantUmlInclude(url, [dirPath, ...includePaths], includeStack, vfs, logger)
           if (result.skip) {

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -124,7 +124,7 @@ function preprocessPlantUmlIncludes (diagramText, dirPath, includeOnce, includeS
           const target = parseTarget(args[1])
           const urlSub = target.url.split('!')
           const trailingContent = target.comment
-          const url = urlSub[0].replace(/\\ /g, ' ').replace(/(\r\n|\n|\r|\s*)$/mg, '')
+          const url = urlSub[0].replace(/\\ /g, ' ').replace(/\s+$/g, '')
           const sub = urlSub[1]
           const result = readPlantUmlInclude(url, [dirPath, ...includePaths], includeStack, vfs, logger)
           if (result.skip) {

--- a/test/preprocess.spec.js
+++ b/test/preprocess.spec.js
@@ -201,6 +201,14 @@ ${includedText}
     expect(preprocessPlantUML(diagramTextWithExistingLocalIncludeFile, {})).to.be.equal(diagramTextWithIncludedText)
   })
 
+  it('should return diagramText with inlined local file referenced with "!include local-file-or-url", diagramText with Windows EOL line endings (\\r\\n)', () => {
+    const localStyleSheetPath = 'test/fixtures/docs/diagrams/style.puml'
+    const diagramTextWithExistingLocalIncludeFile = `!include ${localStyleSheetPath} \r\n\r\nBob->Alice: Hello\r\n`
+    const includedText = fs.readFileSync(`${localStyleSheetPath}`, 'utf8')
+    const diagramTextWithIncludedText = `${includedText}\n\r\nBob->Alice: Hello\r\n`
+    expect(preprocessPlantUML(diagramTextWithExistingLocalIncludeFile, {})).to.be.equal(diagramTextWithIncludedText)
+  })
+
   it('should return diagramText with inlined local file referenced with "!include local-file-or-url" and first "@startuml ... @enduml" block', () => {
     const localExistingFileNameWithBlocksPath = 'test/fixtures/plantuml/styles/general.puml'
     const diagramTextWithExistingLocalIncludeFile = `


### PR DESCRIPTION
When a diagram is using Windows EOL line endings (\r\n) and using include
of a stylesheet, an error message is thrown reporting that the file to
include cannot be found (because of a remaining \r on the url of the
code.)
This fix adresses this issue and removes any trailing spaces, \r,\n,\r\n
in the resolved include file.