### PR TITLE
feat: support view as an alias for view-key for asciidoctor-diagram compatibility

### DIFF
--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -155,9 +155,14 @@ const processKroki = async (
       ([key, _]) =>
         !key.endsWith('-option') &&
         !BUILTIN_ATTRIBUTES.includes(key) &&
-        !isNumeric(key),
+        !isNumeric(key) &&
+        key !== 'view',
     ),
   )
+  // `view` is an alias for `view-key` (asciidoctor-diagram compatibility); `view-key` takes precedence.
+  if ('view' in attrs && !('view-key' in opts)) {
+    opts['view-key'] = attrs.view
+  }
   const krokiDiagram = new KrokiDiagram(diagramType, format, diagramText, opts)
   const krokiClient = new KrokiClient(doc, httpClient)
   let block

--- a/test/block-attributes.test.js
+++ b/test/block-attributes.test.js
@@ -85,6 +85,52 @@ alice -> bob
 </div>`,
       )
     })
+    test('converts view attribute to view-key query parameter', async () => {
+      const input = `
+[structurizr,alice-bob,svg,view=SystemContext]
+....
+workspace {
+  model {
+    user = person "User"
+  }
+}
+....
+`
+      const registry = Extensions.create()
+      asciidoctorKroki.register(registry)
+      const html = await convert(input, { extension_registry: registry })
+      assert.ok(
+        html.includes('?view-key=SystemContext'),
+        `Expected view-key query parameter in: ${html}`,
+      )
+      assert.ok(
+        !html.includes('view='),
+        `Expected view attribute not to appear as-is in: ${html}`,
+      )
+    })
+    test('view-key takes precedence over view when both are present', async () => {
+      const input = `
+[structurizr,alice-bob,svg,view=SystemContext,view-key=ContainerView]
+....
+workspace {
+  model {
+    user = person "User"
+  }
+}
+....
+`
+      const registry = Extensions.create()
+      asciidoctorKroki.register(registry)
+      const html = await convert(input, { extension_registry: registry })
+      assert.ok(
+        html.includes('view-key=ContainerView'),
+        `Expected view-key=ContainerView in: ${html}`,
+      )
+      assert.ok(
+        !html.includes('view-key=SystemContext'),
+        `Expected view alias not to override view-key in: ${html}`,
+      )
+    })
     test('assigns sequential figure numbers to multiple titled diagrams', async () => {
       const input = `
 .alice and bob


### PR DESCRIPTION
When both attributes are present, view-key takes precedence over the view alias.

Resolves https://github.com/asciidoctor/asciidoctor-kroki/issues/418