### PR TITLE
feat: add GoAT as a supported diagram type

### DIFF
--- a/docs/modules/ROOT/pages/syntax.adoc
+++ b/docs/modules/ROOT/pages/syntax.adoc
@@ -202,6 +202,9 @@ Kroki currently supports the following diagram libraries:
 |https://github.com/excalidraw/excalidraw[Excalidraw]
 |`excalidraw`
 
+|https://github.com/blampe/goat[GoAT]
+|`goat`
+
 |https://www.graphviz.org/[GraphViz]
 |`graphviz`
 

--- a/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
+++ b/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
@@ -124,6 +124,7 @@ module AsciidoctorExtensions
       ditaa
       erd
       excalidraw
+      goat
       graphviz
       mermaid
       nomnoml
@@ -239,8 +240,8 @@ module AsciidoctorExtensions
         if format == 'png'
           # redirect PNG format to SVG if the diagram library only supports SVG as output format.
           # this is useful when the default format has been set to PNG
-          # Currently, nomnoml, svgbob, wavedrom only support SVG as output format.
-          svg_only_diagram_types = %i[nomnoml svgbob wavedrom]
+          # Currently, goat, nomnoml, svgbob, wavedrom only support SVG as output format.
+          svg_only_diagram_types = %i[goat nomnoml svgbob wavedrom]
           format = 'svg' if svg_only_diagram_types.include?(diagram_type)
         end
         format

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -315,6 +315,7 @@ export default {
       'ditaa',
       'erd',
       'excalidraw',
+      'goat',
       'graphviz',
       'mermaid',
       'nomnoml',

--- a/test/extension.registration.test.js
+++ b/test/extension.registration.test.js
@@ -16,6 +16,7 @@ describe('Registration', () => {
     assert.ok(registry.registeredForBlockMacro('rackdiag'))
     assert.ok(registry.registeredForBlockMacro('wavedrom'))
     assert.ok(registry.registeredForBlockMacro('excalidraw'))
+    assert.ok(registry.registeredForBlockMacro('goat'))
     assert.ok(registry.registeredForBlockMacro('pikchr'))
     assert.ok(registry.registeredForBlockMacro('structurizr'))
     assert.ok(registry.registeredForBlockMacro('diagramsnet'))


### PR DESCRIPTION
Register the goat block and block macro on both the JavaScript and Ruby extensions, document it in the syntax reference, and redirect PNG to SVG for goat since the Kroki GoAT library only outputs SVG.