### PR TITLE
fix: attach source location to skipped diagram warnings

### DIFF
--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -33,20 +33,32 @@ const BUILTIN_ATTRIBUTES = [
   'opts',
 ]
 
-const wrapError = (err, message) => {
-  const errWrapper = new Error(message)
-  errWrapper.stack += `\nCaused by: ${err.stack || 'unknown'}`
-  const result = {
-    err: {
-      package: 'asciidoctor-kroki',
-      message,
-      stack: errWrapper.stack,
-    },
+/**
+ * Build an auto-formatting log message describing a skipped diagram block.
+ *
+ * Delegates to the document's `messageWithContext` (Logger.AutoFormattingMessage)
+ * so the message carries a structured `source_location` — recorded as-is by a
+ * MemoryLogger — while still rendering the location inline through
+ * `inspect()`/`toString()` when a stderr Logger formats the line.
+ *
+ * @param {Object} doc - Asciidoctor document.
+ * @param {Error} err - The error that caused the block to be skipped.
+ * @param {string} diagramType - The diagram type (e.g. "plantuml").
+ * @param {Object} [sourceLocation] - Reader cursor pointing at the block, if any.
+ * @returns {Object|string} An auto-formatting log message.
+ */
+const skipDiagramMessage = (doc, err, diagramType, sourceLocation) => {
+  const text = `Skipping ${diagramType} block: ${err.message || err}`
+  if (typeof doc.messageWithContext === 'function') {
+    return doc.messageWithContext(text, { source_location: sourceLocation })
   }
-  result.$inspect = function () {
-    return JSON.stringify(this.err)
+  // Fallback for Asciidoctor versions without the logging mixin on Document.
+  if (!sourceLocation) {
+    return text
   }
-  return result
+  const message = { text, source_location: sourceLocation }
+  message.inspect = message.toString = () => `${sourceLocation}: ${text}`
+  return message
 }
 
 const createImageSrc = async (doc, krokiDiagram, target, vfs, krokiClient) => {
@@ -197,6 +209,8 @@ function diagramBlock(context) {
     this.process(async (parent, reader, attrs) => {
       const diagramType = this.name.toString()
       const role = attrs.role
+      // Capture the cursor at the block start before read() advances it.
+      const sourceLocation = reader?.cursor
       const diagramText = await reader.read()
       const logger = parent.getDocument().getLogger()
       try {
@@ -210,8 +224,8 @@ function diagramBlock(context) {
           context,
         )
       } catch (err) {
-        const errorMessage = wrapError(err, `Skipping ${diagramType} block.`)
-        logger.warn(errorMessage)
+        const doc = parent.getDocument()
+        logger.warn(skipDiagramMessage(doc, err, diagramType, sourceLocation))
         attrs.role = role ? `${role} kroki-error` : 'kroki-error'
         return this.createBlock(
           parent,
@@ -288,8 +302,8 @@ function diagramBlockMacro(name, context) {
           resource,
         )
       } catch (err) {
-        const errorMessage = wrapError(err, `Skipping ${diagramType} block.`)
-        parent.getDocument().getLogger().warn(errorMessage)
+        const doc = parent.getDocument()
+        doc.getLogger().warn(skipDiagramMessage(doc, err, diagramType))
         attrs.role = role ? `${role} kroki-error` : 'kroki-error'
         return this.createBlock(
           parent,

--- a/test/extension.block.test.js
+++ b/test/extension.block.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 import { describe, test } from 'node:test'
-import { convert, Extensions } from '@asciidoctor/core'
+import { convert, Extensions, MemoryLogger } from '@asciidoctor/core'
 import asciidoctorKroki from '../src/asciidoctor-kroki.js'
 import { assertContains } from './node/utils.js'
 
@@ -51,5 +51,36 @@ alice -> bob
       html,
       '<div class="imageblock sequence kroki-format-svg kroki">',
     )
+  })
+  test('logs a warning with the source location when a diagram block cannot be rendered', async () => {
+    const input = `before
+
+[plantuml,diag,txt]
+....
+alice -> bob
+....
+`
+    const registry = Extensions.create()
+    asciidoctorKroki.register(registry)
+    const memoryLogger = MemoryLogger.create()
+    const html = await convert(input, {
+      extension_registry: registry,
+      logger: memoryLogger,
+      // Unreachable server so getTextContent() fails deterministically offline.
+      attributes: { 'kroki-server-url': 'http://127.0.0.1:1/invalid' },
+    })
+    const logs = memoryLogger.getMessages()
+    assert.strictEqual(logs.length, 1)
+    assert.strictEqual(logs[0].getSeverity(), 'WARN')
+    assert.match(logs[0].getText(), /^Skipping plantuml block: /)
+    // The source location points at the diagram content (line 5 of the input).
+    assert.strictEqual(String(logs[0].getSourceLocation()), '<stdin>: line 5')
+    // The message renders the location inline when formatted by a stderr logger.
+    assertContains(
+      logs[0].message.toString(),
+      '<stdin>: line 5: Skipping plantuml block: ',
+    )
+    // The block is still emitted, tagged with the kroki-error role.
+    assertContains(html, 'kroki-error')
   })
 })


### PR DESCRIPTION
Replace the Opal-era wrapError helper, which relied on the no-longer-called $inspect hook, with skipDiagramMessage built on the pure-JS logging API. It uses doc.messageWithContext (Logger.AutoFormattingMessage) so warnings carry a structured source_location recorded by MemoryLogger while rendering the location inline via inspect()/toString() for stderr loggers. The cursor is captured at the block start before read() advances it, and the message now embeds the underlying error instead of a JSON stack blob.