### PR TITLE
docs: consistent tone and document missing features and behaviors

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -12,7 +12,7 @@
 |`https://kroki.io`
 
 |`kroki-data-uri`
-|Embed images as data-URI elements in HTML so the file is completely self-contained.
+|Embed images as data-URI elements in HTML so the file is completely self-contained. Only applies when `kroki-fetch-diagram` is enabled. The standard Asciidoctor `data-uri` attribute has the same effect. _JavaScript only_ (see xref:_feature_parity[]).
 |`false`
 
 |`kroki-fetch-diagram`
@@ -25,6 +25,8 @@ a|How to retrieve images from the Kroki server:
 * `get` — always use GET requests
 * `post` — always use POST requests
 * `adaptive` — use POST if the URI exceeds `kroki-max-uri-length` characters, otherwise use GET
+
+This attribute only applies when the extension downloads the diagram content itself: when `kroki-fetch-diagram` is enabled, when the image is embedded (data-URI mode or `inline` option), or when a text format is requested. Otherwise, the generated HTML references the image with a GET URL regardless of this attribute. An invalid value falls back to `adaptive` with a warning.
 |`adaptive`
 
 |`kroki-plantuml-include`
@@ -36,7 +38,7 @@ a|How to retrieve images from the Kroki server:
 |
 
 |`kroki-max-uri-length`
-|Maximum URI length before switching to POST when using the `adaptive` HTTP method.
+|Maximum URI length before switching to POST when using the `adaptive` HTTP method. With the `get` method, a warning is logged when the limit is exceeded.
 |`4000`
 |===
 
@@ -93,6 +95,8 @@ Unset it with `:kroki-default-options: none`, `:kroki-default-options!:`, or ove
 == Generated file names
 
 When `kroki-fetch-diagram` is set, diagrams are downloaded and saved to disk.
+Images are saved to the directory defined by the `imagesoutdir` attribute when set; otherwise to the output directory (the `outdir` attribute or the converter `to_dir` option, falling back to the base directory) combined with `imagesdir`.
+
 The generated file name depends on whether you give the diagram a name:
 
 * *Named diagram* — the name is used as-is, so the link stays stable even when the diagram content changes:
@@ -108,6 +112,7 @@ alice -> bob
 generates `my-diagram.svg`.
 
 * *Anonymous diagram* — a content-addressed name such as `diag-<checksum>.svg` is generated so anonymous diagrams never collide.
+If a file with this name already exists on disk, it necessarily has the same content, so the diagram is not downloaded again.
 
 [WARNING]
 ====
@@ -118,11 +123,12 @@ Use unique names to keep links stable.
 == Preprocessing
 
 Some diagram libraries support referencing external entities by URL or accessing filesystem resources.
-For example, PlantUML supports the `!import` directive, and Vega-Lite can load data from a URL.
+For example, PlantUML supports the `!include` directive, and Vega-Lite can load data from a URL.
 
 By default, the Kroki server runs in `SECURE` mode, which restricts access to the local file system and external network resources.
 
 To work around this, Asciidoctor Kroki resolves and loads external resources *before* sending the request to the Kroki server.
+For PlantUML, the whole `!include` family is supported: `!include`, `!include_many`, `!include_once`, `!includeurl`, and `!includesub`.
 This feature is only available when Asciidoctor safe mode is `server` or lower.
 
 [IMPORTANT]
@@ -158,8 +164,12 @@ The JavaScript/Node.js extension and the Ruby gem share the same version and are
 |No
 
 |`kroki-plantuml-include` (single shared file)
+|Yes (`plantuml` and `c4plantuml`)
+|Yes (`plantuml` only)
+
+|`kroki-data-uri`
 |Yes
-|Yes
+|No
 
 |`kroki-default-options`
 |Yes

--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -35,7 +35,7 @@ If you are using the https://github.com/asciidoctor/asciidoctor.js[Asciidoctor.j
 
 [IMPORTANT]
 ====
-Unlike the Ruby CLI, the `--require` (or `-r`) option only loads a library, it does not register extensions.
+Unlike the Ruby CLI, the `--require` (or `-r`) option only loads a library; it does not register extensions.
 With the Asciidoctor.js CLI, you must use `--extension`.
 ====
 
@@ -116,7 +116,7 @@ Create a file named `kroki.html` with the following content and open it in your 
       import { convert, Extensions } from '@asciidoctor/core'
       import asciidoctorKroki from 'asciidoctor-kroki'
 
-      const input = `Let's take an example with a _GraphViz_ "Hello World":
+      const input = `Here is a _GraphViz_ "Hello World" example:
 
 [graphviz]
 ....
@@ -137,7 +137,7 @@ digraph G {
 
 [TIP]
 ====
-If you want to reference a diagram file in a browser environment, you will need to define the base directory using the `base_dir` option.
+To reference a diagram file in a browser environment, define the base directory using the `base_dir` option.
 The extension will automatically use the https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[Fetch API] to read files:
 
 [source,js]
@@ -183,8 +183,6 @@ asciidoc:
   extensions:
     - asciidoctor-kroki
 ----
-
-. Enjoy!
 
 [TIP]
 ====

--- a/docs/modules/ROOT/pages/self-hosted.adoc
+++ b/docs/modules/ROOT/pages/self-hosted.adoc
@@ -1,7 +1,7 @@
 = Self-Hosted Kroki
 :description: How to use Asciidoctor Kroki with your own self-hosted Kroki server.
 
-By default, this extension sends diagrams to https://kroki.io and receives images back.
+By default, the extension sends diagrams to https://kroki.io and receives images back.
 
 You may prefer to use your own server for any of the following reasons:
 

--- a/docs/modules/ROOT/pages/syntax.adoc
+++ b/docs/modules/ROOT/pages/syntax.adoc
@@ -1,5 +1,5 @@
 = Syntax
-:description: Syntax reference for the Asciidoctor Kroki extension: positional attributes, named attributes, options, and supported diagram types.
+:description: Syntax reference for the Asciidoctor Kroki extension: positional attributes, named attributes, options, substitutions, output formats, and supported diagram types.
 
 You can declare positional and named attributes when using the block or macro form.
 
@@ -94,11 +94,16 @@ The following attributes are used by the built-in HTML 5 converter:
 |Image alignment
 
 |`role`
-|CSS class(es) to apply to the image
+|CSS class(es) to apply to the image, in addition to the `kroki` and `kroki-format-<format>` classes that are always added
 
 |`title`
-|Alternative text description of the diagram
+|Block title, displayed as the figure caption
+
+|`caption`
+|Caption prefix displayed before the block title, replacing the automatic `Figure N.` label
 |===
+
+NOTE: The image alt text is derived from `title` when set, then from `target`, and falls back to `Diagram`.
 
 == Options
 
@@ -132,6 +137,34 @@ blockdiag {
 }
 ----
 ....
+
+[NOTE]
+====
+To inline an SVG, the converter must be able to read its content.
+When the `allow-uri-read` attribute is set, the converter fetches the content from the Kroki server URL.
+Otherwise, the extension embeds the diagram as a data-URI (requires safe mode `server` or lower).
+====
+
+== Substitutions
+
+Use the `subs` attribute to apply AsciiDoc substitutions to the diagram source before it is sent to the Kroki server.
+For example, `subs=attributes` substitutes document attributes:
+
+[source,asciidoc]
+....
+:node-color: greenyellow
+
+[blockdiag,subs=attributes]
+----
+blockdiag {
+  Kroki -> generates -> "Block diagrams";
+
+  Kroki [color = "{node-color}"];
+}
+----
+....
+
+WARNING: Do not include the `specialcharacters` substitution: it replaces `<`, `>`, and `&` with HTML entities, which would make the diagram source invalid.
 
 == Diagram-specific options
 
@@ -238,6 +271,9 @@ Kroki currently supports the following diagram libraries:
 |https://github.com/zebreus/symbolator[Symbolator]
 |`symbolator`
 
+|https://github.com/pgf-tikz/pgf[TikZ]
+|`tikz`
+
 |https://github.com/umlet/umlet[UMLet]
 |`umlet`
 
@@ -250,6 +286,9 @@ Kroki currently supports the following diagram libraries:
 |https://github.com/wavedrom/wavedrom[WaveDrom]
 |`wavedrom`
 
+|https://github.com/wireviz/WireViz[WireViz]
+|`wireviz`
+
 |https://github.com/structurizr/dsl[Structurizr]
 |`structurizr`
 
@@ -257,5 +296,18 @@ Kroki currently supports the following diagram libraries:
 |`diagramsnet`
 |===
 
-Each diagram library supports one or more output formats.
+[#output-formats]
+== Output formats
+
+Each diagram library supports one or more output formats: `svg`, `png`, `jpeg`, `pdf`, `base64`, and the text formats `txt`, `atxt`, and `utxt`.
 Consult the https://kroki.io/#support[Kroki documentation] for the supported formats per library.
+
+When a text format is requested, the diagram is rendered as a literal block containing its textual representation (e.g., ASCII art for a PlantUML sequence diagram) instead of an image:
+
+[source,asciidoc]
+....
+[plantuml,format=txt]
+----
+alice -> bob
+----
+....

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -22,6 +22,13 @@ To resolve this issue, choose one of the following approaches:
 
 [NOTE]
 ====
+Setting `kroki-http-method` alone is not enough: without `kroki-fetch-diagram`, the generated HTML references the image with a GET URL, and the request sent by the browser would still be too long.
 When using POST requests, the extension downloads images from the server and stores them locally.
 The images are then referenced using a relative path rather than a direct link to the Kroki server.
 ====
+
+== Diagram rendering failures
+
+When a diagram cannot be converted — for example, the Kroki server is unreachable or a referenced diagram file does not exist — the document conversion does not fail.
+Instead, the extension logs a warning (`Skipping <type> block: <reason>`) and renders the diagram source as-is.
+The `kroki-error` CSS class is added to the resulting block so failed diagrams can be styled or located in the output.

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -35,6 +35,13 @@ vegalite::chart.vlite[svg,role=chart,opts=interactive]
 
 image::https://kroki.io/vegalite/png/eNrtVktz2yAQvvtXMEyOqt9pnNz6To-d6c3jA5ZWEg0CF7Ba26P_3gVb2JJSN8mhTWdyMIb92CffCnY9QuiFiXMoGL0hNLd2ZW4GgxIy1s-4zdfLPleD_QYvfSW4hUE57X8zStLI6SdgYs1XlqMAbdwqzbdKWibEhsRKxsyCxF9C4pxpa4jNmSUmVz9IwtMUNEhL7GYFhqgURWgMLN9ymRETMwGmf3DDrItxh3NclUysweB67teE7KjP4A2NCF3ibDyroib0toYuL9vQuxqaTtrQ-xq6HrWhDzU060Afg6-OwU81NLpuQ7fB4FUb-hwMjiuPLHD0m2i-L3Koxe6gSQum75xuzHUsgNYWKchYJVjfUE0v3TSWKEg5iMTpL4Oql7uzcmKpCi6ZaIJGaReJXAvRkLOf3LQcOFM8vnPilAkDURNLVMG4_A1ouRVw8HOCVGFeHRWo4Vt4bHLf10yiE2Z5Ca0MHSnvSaWhiA7_GFashNJ_P65WJbegFeJWr-E04oZpARnI5L7j258C_XI-6d7p_8H0C0v_PUtFhw2aycxtmM-GERm9xmE8xWEyxmE6HC6eJam7afgLy-8oWIZX26OZnSpd-E8qTWh0lvTihfT_C-ltrgHfHaJzpCGf-QR5fjVcnOuK8XDfEM-tF56c3bFZSq45PsDo0y-CryGIhzQFjj4YikpKlMfkOrmGWlIuE1hhEPhqPLbNgUYNMLioelXvF-H7eDo=[Vega-Lite chart example]
 
+The target can be a path relative to the document, an absolute path, or an `http://`/`https://` URL, in which case the diagram source is downloaded:
+
+[source,asciidoc]
+----
+plantuml::https://example.org/diagrams/hello.puml[svg]
+----
+
 == Include directive
 
 Use the `include` directive to embed a diagram file inline:
@@ -51,7 +58,7 @@ image::https://kroki.io/plantuml/png/eNpzKC5JLCopzc3hSszJTE5V0LVTSMpP4nJIzUsBCgI
 
 == Antora: references and includes
 
-If you use Asciidoctor Kroki with Antora, all file references and includes *must* use https://docs.antora.org/antora/latest/page/resource-id/[Antora Resource IDs].
+If you are using Asciidoctor Kroki with Antora, all file references and includes *must* use https://docs.antora.org/antora/latest/page/resource-id/[Antora Resource IDs].
 Place diagram source files (`.puml`, `.vlite`, etc.) in the https://docs.antora.org/antora/latest/page/partials/[`partials` directory] of your module.
 
 === Block macros


### PR DESCRIPTION
**Tone and wording**

Adopt a consistent, neutral technical register across all pages: imperative for instructions, removal of conversational phrasings ("Enjoy!", "Let's take an example…"), and harmonization of recurring wordings ("If you are using", "the extension").

**Coverage — undocumented features**

- Add **TikZ** and **WireViz** to the supported diagram types table (all 30 registered types are now listed)
- New **Output formats** section: supported formats, and the text formats (`txt`, `atxt`, `utxt`) rendered as literal blocks (e.g. PlantUML ASCII art)
- New **Substitutions** section documenting the `subs` attribute, with a warning about `specialcharacters`
- Document URL targets (`http://`, `https://`) for the block macro form
- Document the `caption` attribute, the automatic `kroki` and `kroki-format-<format>` CSS classes, and the alt text derivation; fix the `title` attribute description

**Coverage — missing notes and clarifications**

- `kroki-data-uri`: only applies with `kroki-fetch-diagram`, JavaScript only (added to the feature parity table), and the standard `data-uri` attribute has the same effect
- `kroki-http-method`: clarify that it only applies when the extension downloads the diagram content itself; invalid values fall back to `adaptive`
- Document where fetched images are saved (`imagesoutdir`, `outdir`/`to_dir` + `imagesdir`) and the on-disk reuse of content-addressed diagrams
- Fix a factual error: PlantUML preprocessing resolves `!include` (not `!import`), and list the whole supported family (`!include`, `!include_many`, `!include_once`, `!includeurl`, `!includesub`)
- Feature parity: `kroki-plantuml-include` applies to `c4plantuml` in JavaScript only
- New **Diagram rendering failures** troubleshooting section (warning, `kroki-error` class), and explain why `kroki-fetch-diagram` is needed to avoid 414 errors

