### PR TITLE
fix(test): make the Testcontainers-backed test suites reliable on slow CI runners

### DIFF
--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -70,6 +70,11 @@ jobs:
       run: |
         npm ci
         npx playwright install chromium
+    - name: Pull Kroki images used by Testcontainers
+      # pulling ahead of time keeps slow registry downloads out of the
+      # test hook timeouts (container tests only run on Linux)
+      if: runner.os == 'Linux'
+      run: grep -rhoE 'yuzutech/kroki:[0-9.]+' test/node/*.test.js | sort -u | xargs -n1 docker pull
     - name: Test
       run: npm t
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Increase the test suite timeout from 10 to 120 seconds for the Node.js tests that start a Kroki server with Testcontainers. The 10-second suite timeout also covered the container startup, so on slow CI runners the whole suite was cancelled (`test did not finish before its parent and was cancelled`) before the tests could run.
+
 ## [1.0.1] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Increase the test suite timeout from 10 to 120 seconds for the Node.js tests that start a Kroki server with Testcontainers. The 10-second suite timeout also covered the container startup, so on slow CI runners the whole suite was cancelled (`test did not finish before its parent and was cancelled`) before the tests could run.
+- Fix intermittent CI failures (`test did not finish before its parent and was cancelled`) in the Node.js tests that start a Kroki server with Testcontainers. The 10-second suite timeout also covered the container startup and the 60-second `before` hook timeout was shorter than a slow image pull (both test files pull their own Kroki image in parallel, which can take more than a minute on CI runners). The suite timeout is raised to 120 seconds, the `before` hook timeout to 180 seconds, and the CI workflow now pulls the Kroki images before running the tests so registry downloads no longer count against test timeouts.
 
 ## [1.0.1] - 2026-07-15
 

--- a/test/node/extension.test.js
+++ b/test/node/extension.test.js
@@ -55,7 +55,7 @@ describe('Conversion', () => {
     }
   }
 
-  describe('When extension is registered', { timeout: 10000 }, () => {
+  describe('When extension is registered', { timeout: 120000 }, () => {
     if (os.platform() !== 'win32') {
       before(
         async () => {

--- a/test/node/extension.test.js
+++ b/test/node/extension.test.js
@@ -71,7 +71,8 @@ describe('Conversion', () => {
             .start()
           krokiServerUrl = `http://${container.getHost()}:${container.getMappedPort(8000)}`
         },
-        { timeout: 60000 },
+        // pulling the Kroki image alone can take more than a minute on CI runners
+        { timeout: 180000 },
       )
 
       after(

--- a/test/node/kroki-client.test.js
+++ b/test/node/kroki-client.test.js
@@ -24,7 +24,8 @@ describe('Kroki HTTP client — Adaptive mode with real server', {
           .start()
         krokiServerUrl = `http://${container.getHost()}:${container.getMappedPort(8000)}`
       },
-      { timeout: 60000 },
+      // pulling the Kroki image alone can take more than a minute on CI runners
+      { timeout: 180000 },
     )
 
     after(

--- a/test/node/kroki-client.test.js
+++ b/test/node/kroki-client.test.js
@@ -13,7 +13,7 @@ let container
 let krokiServerUrl
 
 describe('Kroki HTTP client — Adaptive mode with real server', {
-  timeout: 10000,
+  timeout: 120000,
 }, () => {
   const isMacOS = os.platform() === 'darwin'
   if (os.platform() !== 'win32') {


### PR DESCRIPTION
The Node.js tests that start a Kroki server with Testcontainers failed intermittently in CI with `test did not finish before its parent and was cancelled`. Two timeouts were too tight:

- The 10-second suite timeout also covered the container startup, so the whole suite could be cancelled before any test ran. It is raised to 120 seconds.
- The 60-second `before` hook timeout was shorter than a slow image pull: `extension.test.js` and `kroki-client.test.js` each pull their own Kroki image in parallel (`node --test` runs one process per file), which took over a minute on a CI runner (`failureType: 'hookFailed'`). The hook timeout is raised to 180 seconds.

The CI workflow now also pre-pulls the Kroki images (extracted from the test files, Linux only) before running `npm t`, so registry downloads no longer count against test timeouts at all.

Note: the two test files intentionally keep different Kroki versions (0.28.0 and 0.30.1) for now. Unifying them would require regenerating the expected SVG fixtures, since both PlantUML and Vega-Lite output changed between those versions.
